### PR TITLE
Fix incorrect constant and type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,7 @@ import time
 # import the "show info" tool from utils.py
 from aqt.utils import showInfo
 
+
 def answerButtons(self, card):
     return 2
 
@@ -23,9 +24,11 @@ SchedulerV2.answerButtons = answerButtons
 oldFlush = Card.flush
 oldFlushSched = Card.flushSched
 
+
 def reprocess(card):
     currentSecond = time.time()
-    lastReviewSecond = card.col.db.scalar("SELECT id FROM revlog WHERE cid = ? ORDER BY id DESC", card.id) // 1000
+    lastReviewSecond = card.col.db.scalar(
+        "SELECT id FROM revlog WHERE cid = ? ORDER BY id DESC", card.id) // 1000
     ivlInHour = ResultsandTimes(card.id)
     ivlInDay = round(ivlInHour/24)
     ivlInSecond = ivlInHour * 3600
@@ -43,10 +46,11 @@ def reprocess(card):
     if nextReviewSecond <= currentSecond:
         # card is already due
         card.queue = QUEUE_TYPE_REV
-        card.type = CARD_TYPE_REV 
+        card.type = CARD_TYPE_REV
         showInfo(f"This card is overdue. The next interval will be {card.ivl}")
-        card.ivl = self.today # set to something else? Originally card.ivl = ivlInHour
-        card.due = card.col.sched.today # TODO: find real day  # Originally card.due = self.today
+        card.ivl = self.today  # set to something else? Originally card.ivl = ivlInHour
+        # TODO: find real day  # Originally card.due = self.today
+        card.due = card.col.sched.today
         # showInfo(f"Setting its due date to today since already due.")
         return
 
@@ -73,23 +77,31 @@ def flush(self):
         # Only consider review and learning
         reprocess(self)
     oldFlush(self)
+
+
 Card.flush = flush
+
+
 def flushSched(self):
     print("our flush")
     if self.queue in {QUEUE_TYPE_LRN, QUEUE_TYPE_DAY_LEARN_RELEARN, QUEUE_TYPE_REV}:
         # Only consider review and learning
         reprocess(self)
     oldFlushSched(self)
+
+
 Card.flushSched = flushSched
 
+
 def ResultsandTimes(cardID, initialModel=ebisuAllInOne.defaultModel(24, 3)):
-    ''' 
+    '''
     Takes as input the cardID and initial guess of the model, and returns the next interval in hours from the last interval
     The default model assumes a beta distribution with alpha = beta = 3, half life = 24 hours.
     '''
 
     # pull reviewresults from database
-    reviewResults = mw.col.db.list("SELECT ease FROM revlog WHERE cid = ?", cardID) 
+    reviewResults = mw.col.db.list(
+        "SELECT ease FROM revlog WHERE cid = ?", cardID)
 
     # format properly: ease is encoded as 1(wrong), 2(hard), 3(ok), 4(easy) for review, and  1(wrong), 2(ok), 3(easy) for learn/relearn
     # just convert it to a list of True/False corresponding to review result
@@ -99,36 +111,38 @@ def ResultsandTimes(cardID, initialModel=ebisuAllInOne.defaultModel(24, 3)):
     reviewTimes = mw.col.db.list("SELECT id FROM revlog WHERE cid = ?", cardID)
 
     # format properly: id is actually the epoch-millisecond timestamp when the review was performed
-    reviewTimes = [datetime.fromtimestamp(time / 1000.00) for time in reviewTimes]
+    reviewTimes = [datetime.fromtimestamp(
+        time / 1000.00) for time in reviewTimes]
 
     previousTime, model = reviewTimes[0], initialModel
 
     # showInfo(f"Review Results are {reviewResults},\n Review Times are {reviewTimes},\n previousTime is {previousTime},\n model is {model}")
 
-
-    # Here, we start updating the recall successively based on the entire review history of the card. 
+    # Here, we start updating the recall successively based on the entire review history of the card.
     for i in range(1, len(reviewTimes)):
         # showInfo(f"Review {i} at {reviewTimes[i]}")
-        timedifference_hours = (reviewTimes[i] - reviewTimes[i-1]).total_seconds()/3600
-        
+        timedifference_hours = (
+            reviewTimes[i] - reviewTimes[i-1]).total_seconds()/3600
+
         # showInfo(f"Elapsed {round(timedifference_hours,2)} hours\nPredicted {predictRecall(model, timedifference_hours, exact = True)}\nResult: {reviewResults[i]} \n")
-        
-        model = a, b, t = ebisuAllInOne.updateRecall(prior = model, result = reviewResults[i], tnow = timedifference_hours)
+
+        model = a, b, t = ebisuAllInOne.updateRecall(
+            prior=model, result=reviewResults[i], tnow=timedifference_hours)
         # showInfo(f"Updated model: {round(a,2), round(b,2), round(t,2)} \nThe estimated half-life is {round(modelToPercentileDecay(model), 3)}")
 
-
-    # modelToPercentileDecay estimates how long (in hours) it will take for a model to decay to a given percentile 
+    # modelToPercentileDecay estimates how long (in hours) it will take for a model to decay to a given percentile
     # Here, the percentile is 0.5, which is the half-life of the memory.
     # showInfo(f"model to percentile decay is {ebisuAllInOne.modelToPercentileDecay(model)}")
     return ebisuAllInOne.modelToPercentileDecay(model)
 
+
 def ebisuAll():
-    for cid in mw.col.db.list(f"SELECT id FROM cards where queue in ({QUEUE_LRN}, {QUEUE_DAY_LRN}, {QUEUE_REV})"):
+    for cid in mw.col.db.list(f"SELECT id FROM cards where queue in ({QUEUE_TYPE_LRN}, {QUEUE_TYPE_DAY_LEARN_RELEARN}, {QUEUE_TYPE_REV})"):
         card = mw.col.getCard(cid)
         card.flush()
+
 
 action = QAction(mw)
 action.setText("Ebisu")
 mw.form.menuTools.addAction(action)
 action.triggered.connect(ebisuAll)
-

--- a/__init__.py
+++ b/__init__.py
@@ -47,10 +47,10 @@ def reprocess(card):
         # card is already due
         card.queue = QUEUE_TYPE_REV
         card.type = CARD_TYPE_REV
-        showInfo(f"This card is overdue. The next interval will be {card.ivl}")
-        card.ivl = self.today  # set to something else? Originally card.ivl = ivlInHour
+        # showInfo(f"This card is overdue. The next interval will be {card.ivl}")
+        card.ivl = int(ivlInHour)
         # TODO: find real day  # Originally card.due = self.today
-        card.due = card.col.sched.today
+        card.due = int(card.col.sched.today)
         # showInfo(f"Setting its due date to today since already due.")
         return
 
@@ -58,7 +58,7 @@ def reprocess(card):
         # more than 2 day. We can average and set to review
         card.queue = QUEUE_TYPE_REV
         card.type = CARD_TYPE_REV
-        card.due = card.col.sched.today + remainingIntervalInDay
+        card.due = int(card.col.sched.today + remainingIntervalInDay)
         card.ivl = ivlInDay
         # showInfo(f"Setting its due date to the day {card.due}, in {remainingIntervalInDay} days.")
         return
@@ -66,7 +66,7 @@ def reprocess(card):
     # at most 2 day. Stay in learning mode.
     card.queue = QUEUE_TYPE_LRN
     card.type = CARD_TYPE_LRN
-    card.due = round(nextReviewSecond)
+    card.due = int(round(nextReviewSecond))
     t = time.localtime(nextReviewSecond)
     # showInfo(f"Setting its due date to {card.due}, i.e. {time.strftime('%y.%m.%d %H:%M:%S', t)}.")
 


### PR DESCRIPTION
- Fix | Update constant and automatic formatting fixes my editor threw in
- Fix | Fixes name 'self' is not defined and expected one of: int, long

Fixes two errors:

```
Err
An error occurred. Please start Anki while holding down the shift key, which will temporarily disable the add-ons you have installed.
If the issue only occurs when add-ons are enabled, please use the Tools > Add-ons menu item to disable some add-ons and restart Anki, repeating until you discover the add-on that is causing the problem.
When you've discovered the add-on that is causing the problem, please report the issue on the add-on support site.
Debug info:
Anki 2.1.35 (84dcaa86) Python 3.8.0 Qt 5.14.2 PyQt 5.14.2
Platform: Mac 10.16
Flags: frz=True ao=True sv=2
Add-ons, last update check: 2020-11-29 16:56:23
Add-ons possibly involved: ⁨Anki-Ebisu⁩

Caught exception:
Traceback (most recent call last):
File "/Users/rosstodd/Library/Application Support/Anki2/addons21/Anki-Ebisu/**init**.py", line 126, in ebisuAll
for cid in mw.col.db.list(f"SELECT id FROM cards where queue in ({QUEUE_LRN}, {QUEUE_DAY_LRN}, {QUEUE_REV})"):
NameError: name 'QUEUE_LRN' is not defined
```
```
Error:
An error occurred. Please start Anki while holding down the shift key, which will temporarily disable the add-ons you have installed.
If the issue only occurs when add-ons are enabled, please use the Tools > Add-ons menu item to disable some add-ons and restart Anki, repeating until you discover the add-on that is causing the problem.
When you've discovered the add-on that is causing the problem, please report the issue on the add-on support site.
Debug info:
Anki 2.1.35 (84dcaa86) Python 3.8.0 Qt 5.14.2 PyQt 5.14.2
Platform: Mac 10.16
Flags: frz=True ao=True sv=2
Add-ons, last update check: 2020-11-29 16:56:23
Add-ons possibly involved: ⁨Anki-Ebisu⁩

Caught exception:
Traceback (most recent call last):
File "/Users/[...]/Library/Application Support/Anki2/addons21/Anki-Ebisu/**init**.py", line 142, in ebisuAll
card.flush()
File "/Users/rosstodd/Library/Application Support/Anki2/addons21/Anki-Ebisu/**init**.py", line 78, in flush
reprocess(self)
File "/Users/[...]/Library/Application Support/Anki2/addons21/Anki-Ebisu/**init**.py", line 51, in reprocess
card.ivl = self.today  # set to something else? Originally card.ivl = ivlInHour
NameError: name 'self' is not defined
```
